### PR TITLE
Pass resolved values from Promise.all in the correct order

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,8 +137,9 @@ SynchronousPromise.all = function () {
   return new SynchronousPromise(function (resolve, reject) {
     var
       allData = [],
+      numResolved = 0,
       doResolve = function () {
-        if (allData.length === args.length) {
+        if (numResolved === args.length) {
           resolve(allData);
         }
       },
@@ -150,9 +151,10 @@ SynchronousPromise.all = function () {
         rejected = true;
         reject(err);
       };
-    args.forEach(function (arg) {
+    args.forEach(function (arg, idx) {
       arg.then(function (thisResult) {
-        allData.push(thisResult);
+        allData[idx] = thisResult;
+        numResolved += 1;
         doResolve();
       }).catch(function (err) {
         doReject(err);

--- a/index.spec.js
+++ b/index.spec.js
@@ -426,6 +426,29 @@ describe('synchronous-promise', function () {
       expect(captured).to.contain('abc');
       expect(captured).to.contain('123');
     });
+    it('should resolve with values in the correct order', function() {
+      var
+        resolve1,
+        resolve2,
+        captured;
+
+      var p1 = create(function(resolve) {
+        resolve1 = resolve;
+      });
+
+      var p2 = create(function(resolve) {
+        resolve2 = resolve;
+      });
+
+      SynchronousPromise.all([p1, p2]).then(function(data) {
+        captured = data;
+      });
+
+      resolve2('a');
+      resolve1('b');
+
+      expect(captured).to.deep.equal(['b', 'a']);
+    });
     it('should reject if any promise rejects', function () {
       var
         p1 = createResolved('abc'),


### PR DESCRIPTION
SynchronousPromise.all assumes that the given promises will resolve in the correct order, which isn't always the case (even with synchronous promises -- the `resolve()` function can be saved and called later).

I've added a test that checks that the arguments are passed in the correct order, and fixes the implementation of SynchronousPromise.all.