### PR TITLE
Fix then .. catch chain

### DIFF
--- a/index.spec.js
+++ b/index.spec.js
@@ -323,9 +323,13 @@ describe("synchronous-promise", function () {
 
       // Assert
       setTimeout(function () {
-        expect(capturedA).to.equal(expected);
-        expect(capturedB).to.equal(expected);
-        done();
+        try {
+          expect(capturedA).to.equal(expected);
+          expect(capturedB).to.equal(expected);
+          done();
+        } catch (e) {
+          done(e);
+        }
       }, 100);
     });
 
@@ -382,10 +386,14 @@ describe("synchronous-promise", function () {
 
       // Assert
       setTimeout(function () {
-        expect(capturedA).to.equal(expected);
-        expect(capturedB).to.be.null;
-        expect(secondResolve).to.equal("456");
-        done();
+        try {
+          expect(capturedA).to.equal(expected);
+          expect(capturedB).to.be.null;
+          expect(secondResolve).to.equal("456");
+          done();
+        } catch (e) {
+          done(e);
+        }
       }, 100);
     });
 

--- a/index.spec.js
+++ b/index.spec.js
@@ -66,7 +66,7 @@ describe("synchronous-promise", function () {
 
       expect(received).to.eql(new Error(expected));
     });
-    it("should call into the failure function when the predecessor fails", function () {
+    it("should call into following catch rather than the sibling onRejected if onResolved fails", function () {
       var
         sut = createResolved(),
         expected = "the error",
@@ -80,8 +80,8 @@ describe("synchronous-promise", function () {
         catchCaptured = e;
       });
 
-      expect(captured).to.equal(expected);
-      expect(catchCaptured).to.be.null;
+      expect(captured).to.be.null;
+      expect(catchCaptured).to.equal(expected);
     });
     it("should bring the first resolve value into the first then", function () {
       var

--- a/index.spec.js
+++ b/index.spec.js
@@ -446,6 +446,34 @@ describe("synchronous-promise", function () {
         promise.resume();
         expect(captured).to.equal("moo");
       });
+      it("should return a promise in paused state with no initial data and being rejected on resume", function () {
+        var
+          captured,
+          expected = new Error("moon"),
+          promise = SynchronousPromise.resolve().pause().then(function () {
+            throw expected
+          }).catch(function (e) {
+            captured = e;
+          });
+        expect(captured).not.to.be.defined;
+        promise.resume();
+        expect(captured).to.equal(expected);
+      });
+      it("should return a promise in paused state with no initial data and being resolved after a catch on resume", function () {
+        var
+          captured,
+          error = new Error("moon"),
+          promise = SynchronousPromise.resolve().pause().then(function () {
+            throw error
+          }).catch(function (e) {
+            return e.message;
+          }).then(function (m) {
+            captured = m;
+          });
+        expect(captured).not.to.be.defined;
+        promise.resume();
+        expect(captured).to.equal("moon");
+      });
     });
   });
   describe("resume", function () {

--- a/index.spec.js
+++ b/index.spec.js
@@ -31,7 +31,7 @@ describe("synchronous-promise", function () {
   describe("then", function () {
     it("should return the same resolved promise", function () {
       var sut = createResolved();
-      expect(sut.then(function () { })).to.equal(sut);
+      expect(sut.then(null, function () { })).to.equal(sut);
     });
     it("should return the same resolved promise v2", function () {
       var
@@ -249,7 +249,7 @@ describe("synchronous-promise", function () {
       providedReject(expected);
       expect(captured).to.equal(expected);
     });
-    it("should return the same promise", function () {
+    it("should return a resolved promise if doesn't thrown an error", function () {
       var
         promise = createRejected("123"),
         result = promise.catch(function (data) {
@@ -258,7 +258,7 @@ describe("synchronous-promise", function () {
 
       expect(result).to.exist;
       expect(result).to.be.instanceOf(SynchronousPromise);
-      expect(result).to.equal(promise);
+      expect(result.status).to.be.equal("resolved");
     });
     it("should not interfere with a later then if there is no error", function () {
       var
@@ -274,19 +274,22 @@ describe("synchronous-promise", function () {
       expect(capturedError).to.be.null;
       expect(captured).to.equal(expected);
     });
-    it("should not be called if the promise is handled by a previous onRejected handler", function () {
+    it("should not be called if the promise is handled successful by a previous onRejected handler", function () {
       var
         expected = new Error("123"),
+        notExpected = new Error("Not expected"),
         capturedError = null;
       createRejected(expected).then(function () {}, function (e) {
         capturedError = e
       })
       .catch(function () {
         /* purposely don't return anything */
+        capturedError = notExpected;
       })
+
       expect(capturedError).to.equal(expected);
     });
-    it("should prevent then handlers after the error from being called", function () {
+    it("should prevent the handlers after the error from being called", function () {
       var
         captured = null;
       createResolved("123").catch(function (e) {
@@ -431,7 +434,7 @@ describe("synchronous-promise", function () {
       expect(calls).to.equal(0);
     })
     describe("starting paused", function () {
-      it("should return a promise in paused state with no initial data", function () {
+      it("should return a promise in paused state with no initial data and being resolved on resume", function () {
         var
           captured,
           promise = SynchronousPromise.resolve().pause().then(function () {


### PR DESCRIPTION
On the way to fix one issue that I found in this library meanwhile I was using for testing one of our implementations, I ended up having to do a quite intense refactoring in order to fix the bug, as I added new test cases which the current version doesn't pass and the first minor changes that I did to pass those new broke some of the current ones, so I did numerous changes in the implementation to pass all of them (current specs + new ones).

The bug which motivated this PR is as the one shown in the next example:

```js
SynchronousPromise.reject('something')
    .then(
            (v) => console.log(`onResolvedHandler: ${v}`),
            (e) => console.log(`onRejectedHandler: ${e}`)
    )
     .catch((e) => console.log(`catch: ${e}`))
```

The output to the console is `catch: something` and it should be `onRejectedHandler: something` as you can check using the standard `Promise` implementation.
