### PR TITLE
Implement Promise.all([]) for empty arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,6 +177,9 @@ SynchronousPromise.all = function () {
   if (Array.isArray(args[0])) {
     args = args[0];
   }
+  if (!args.length) {
+    return SynchronousPromise.resolve([]);
+  }
   return new SynchronousPromise(function (resolve, reject) {
     var
       allData = [],

--- a/index.spec.js
+++ b/index.spec.js
@@ -613,6 +613,17 @@ describe("synchronous-promise", function () {
       expect(captured).to.contain("abc");
       expect(captured).to.contain("123");
     });
+    it("should resolve empty promise array", function () {
+      var
+        all = SynchronousPromise.all([]),
+        captured = null;
+
+      all.then(function (data) {
+        captured = data;
+      });
+
+      expect(captured).to.have.length(0);
+    });
     it("should resolve with values in the correct order", function () {
       var
         resolve1,


### PR DESCRIPTION
Native `Promise`es do resolve empty arrays. I think this behavior should be reflected here as well.