### PR TITLE
Accept none promise arguments for .all()

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ SynchronousPromise.all = function () {
         reject(err);
       };
     args.forEach(function (arg, idx) {
-      arg.then(function (thisResult) {
+      SynchronousPromise.resolve(arg).then(function (thisResult) {
         allData[idx] = thisResult;
         numResolved += 1;
         doResolve();

--- a/index.spec.js
+++ b/index.spec.js
@@ -1,4 +1,4 @@
-/* 
+/*
 * linting omitted on spec mainly because jslint doesn"t seem to allow the
 * mocha expression-like syntax
 */
@@ -588,6 +588,20 @@ describe("synchronous-promise", function () {
         p1 = createResolved("abc"),
         p2 = createResolved("123"),
         all = SynchronousPromise.all(p1, p2),
+        captured = null;
+
+      all.then(function (data) {
+        captured = data;
+      });
+
+      expect(captured).to.have.length(2);
+      expect(captured).to.contain("abc");
+      expect(captured).to.contain("123");
+    });
+
+    it("should resolve with all values from given promise or none promise variable args", function () {
+      var
+        all = SynchronousPromise.all(["123", createResolved("abc")]),
         captured = null;
 
       all.then(function (data) {


### PR DESCRIPTION
Promise.all works with non promise arguments, per the spec they are "ignored" which is a really weird way of saying the aren't ignored :P 

Since everything is sync here the simplest way to handle it is to wrap the arg in `SynchronousPromise.resolve`

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all