### PR TITLE
Implement `.allSettled`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,16 @@ export interface SynchronousPromise<T> extends Promise<T> {
 }
 
 export type ValueOrPromiseOfValue<T> = T | PromiseLike<T>
+export type RejectedOutcome = {
+  status: "rejected",
+  reason: any
+}
+export type FulfilledOutcome<T> = {
+  status: "fulfilled",
+  value: T
+}
+export type SettledOutcome<T> = FulfilledOutcome<T> | RejectedOutcome
+
 export interface SynchronousPromiseConstructor {
   /**
     * A reference to the prototype.
@@ -26,6 +36,16 @@ export interface SynchronousPromiseConstructor {
     */
   all<T>(v1: ValueOrPromiseOfValue<T>[]): SynchronousPromise<T[]>;
   all<TAll>(...values: ValueOrPromiseOfValue<TAll>[]): SynchronousPromise<TAll[]>;
+
+  /**
+    * Creates a Promise that is resolved with an array of outcome objects after all of the provided Promises
+    * have settled. Each outcome object has a .status of either "fulfilled" or "rejected" and corresponding
+    * "value" or "reason" properties.
+    * @param values An array of Promises.
+    * @returns A new Promise.
+    */
+  allSettled<T>(v1: ValueOrPromiseOfValue<T>[]): SynchronousPromise<SettledOutcome<T>[]>;
+  allSettled<TAllSettled>(...values: ValueOrPromiseOfValue<TAllSettled>[]): SynchronousPromise<SettledOutcome<TAllSettled>[]>;
 
   /**
     * Creates a Promise that is resolved or rejected when any of the provided Promises are resolved

--- a/index.js
+++ b/index.js
@@ -346,6 +346,42 @@ SynchronousPromise.all = function () {
   });
 };
 
+SynchronousPromise.allSettled = function () {
+  var args = makeArrayFrom(arguments);
+  if (Array.isArray(args[0])) {
+    args = args[0];
+  }
+  if (!args.length) {
+    return SynchronousPromise.resolve([]);
+  }
+  return new SynchronousPromise(function (resolve) {
+    var
+      allData = [],
+      numSettled = 0,
+      doSettled = function () {
+        numSettled += 1;
+        if (numSettled === args.length) {
+          resolve(allData);
+        }
+      };
+    args.forEach(function (arg, idx) {
+      SynchronousPromise.resolve(arg).then(function (thisResult) {
+        allData[idx] = {
+          status: "fulfilled",
+          value: thisResult
+        };
+        doSettled();
+      }).catch(function (err) {
+        allData[idx] = {
+          status: "rejected",
+          reason: err
+        };
+        doSettled();
+      });
+    });
+  });
+};
+
 /* jshint ignore:start */
 if (Promise === SynchronousPromise) {
   throw new Error("Please use SynchronousPromise.installGlobally() to install globally");

--- a/index.spec.js
+++ b/index.spec.js
@@ -761,6 +761,122 @@ describe("synchronous-promise", function () {
       expect(capturedError).to.equal("123");
     });
   });
+
+  describe("static allSettled", function () {
+    it("should be a function", function () {
+      expect(SynchronousPromise.allSettled).to.be.a("function")
+    });
+
+    it("should resolve with all values from given resolved promises as variable args", function () {
+      const p1 = createResolved("abc"),
+        p2 = createResolved("123"),
+        allSettled = SynchronousPromise.allSettled(p1, p2);
+      let captured = null;
+
+      allSettled.then(function (data) {
+        captured = data;
+      });
+
+      expect(captured).to.have.length(2);
+      expect(captured).to.deep.contain({ status: "fulfilled", value: "abc" });
+      expect(captured).to.deep.contain({ status: "fulfilled", value: "123" });
+    });
+
+    it("should resolve with all values from given rejected promises as variable args", function () {
+      const error1 = new Error("error1");
+      const error2 = new Error("error2");
+      const p1 = createRejected(error1),
+        p2 = createRejected(error2),
+        allSettled = SynchronousPromise.allSettled(p1, p2);
+      let captured = null;
+
+      allSettled.then(function (data) {
+        captured = data;
+      });
+
+      expect(captured).to.have.length(2);
+      expect(captured).to.deep.contain({ status: "rejected", reason: error1 });
+      expect(captured).to.deep.contain({ status: "rejected", reason: error2 });
+    });
+
+    it("should resolve with all values from given promise or none promise variable args", function () {
+      const allSettled = SynchronousPromise.allSettled(["123", createResolved("abc")]);
+      let captured = null;
+
+      allSettled.then(function (data) {
+        captured = data;
+      });
+
+      expect(captured).to.have.length(2);
+      expect(captured).to.deep.contain({ status: "fulfilled", value: "abc" });
+      expect(captured).to.deep.contain({ status: "fulfilled", value: "123" });
+    });
+
+    it("should resolve with all values from given resolved promises as an array", function () {
+      const p1 = createResolved("abc"),
+        p2 = createResolved("123"),
+        allSettled = SynchronousPromise.allSettled([p1, p2]);
+      let captured = null;
+
+      allSettled.then(function (data) {
+        captured = data;
+      });
+
+      expect(captured).to.have.length(2);
+      expect(captured).to.deep.contain({ status: "fulfilled", value: "abc" });
+      expect(captured).to.deep.contain({ status: "fulfilled", value: "123" });
+    });
+
+    it("should resolve empty promise array", function () {
+      const allSettled = SynchronousPromise.allSettled([]);
+      let captured = null;
+
+      allSettled.then(function (data) {
+        captured = data;
+      });
+
+      expect(captured).to.have.length(0);
+    });
+
+    it("should resolve with values in the correct order", function () {
+      let resolve1 = undefined,
+        resolve2 = undefined,
+        captured = undefined;
+
+      const p1 = create(function (resolve) {
+        resolve1 = resolve;
+      });
+
+      const p2 = create(function (resolve) {
+        resolve2 = resolve;
+      });
+
+      SynchronousPromise.allSettled([p1, p2]).then(function (data) {
+        captured = data;
+      });
+
+      resolve2("a");
+      resolve1("b");
+
+      expect(captured).to.deep.equal([
+        { status: "fulfilled", value: "b" },
+        { status: "fulfilled", value: "a" }
+      ]);
+    });
+
+    it("should only resolve after all promises are settled", function () {
+      const p1 = createResolved("abc"),
+        p2 = createRejected("123"),
+        allSettled = SynchronousPromise.allSettled(p1, p2);
+      let capturedData = null;
+      allSettled.then(function (data) {
+        capturedData = data;
+      });
+
+      expect(capturedData).to.have.length(2);
+    });
+  });
+
   describe("static unresolved", function () {
     it("should exist as a function", function () {
       // Arrange


### PR DESCRIPTION
Implements `SynchronousPromise.allSettled` as per #21 

This adds:
- static `allSettled` method.
- corresponding tests
- corresponding typings

As per spec, the allSettled method aims to resolve after all promises have either been resolved or rejected. The return value
is an array of outcome objects with a `status` and either `value` or `reason` key.

I think this needs some tweaking for the types. Maybe there is a better way to represent the different outcome objects.
I would love some suggestions @fluffynuts.

Thanks for the nice challenge with this issue, awesome project!