### PR TITLE
Add AggregateError to .any() in supported environments

### DIFF
--- a/index.js
+++ b/index.js
@@ -356,6 +356,12 @@ SynchronousPromise.any = function () {
     args = args[0];
   }
   if (!args.length) {
+    /* jshint ignore:start */
+    if (typeof window !== "undefined" && "AggregateError" in window) {
+     return SynchronousPromise.reject(new window.AggregateError([]));
+    }
+    /* jshint ignore:end */
+
     return SynchronousPromise.reject({ errors: [] });
   }
   return new SynchronousPromise(function (resolve, reject) {
@@ -364,6 +370,13 @@ SynchronousPromise.any = function () {
       numRejected = 0,
       doReject = function () {
         if (numRejected === args.length) {
+          /* jshint ignore:start */
+          if (typeof window !== "undefined" && "AggregateError" in window) {
+            reject(new window.AggregateError(allErrors));
+            return;
+          }
+          /* jshint ignore:end */
+
           reject({ errors: allErrors });
         }
       },

--- a/index.js
+++ b/index.js
@@ -350,19 +350,23 @@ SynchronousPromise.all = function () {
   });
 };
 
+function createAggregateErrorFrom(errors) {
+  /* jshint ignore:start */
+  if (typeof window !== "undefined" && "AggregateError" in window) {
+    return new window.AggregateError(errors);
+  }
+  /* jshint ignore:end */
+
+  return { errors: errors };
+}
+
 SynchronousPromise.any = function () {
   var args = makeArrayFrom(arguments);
   if (Array.isArray(args[0])) {
     args = args[0];
   }
   if (!args.length) {
-    /* jshint ignore:start */
-    if (typeof window !== "undefined" && "AggregateError" in window) {
-     return SynchronousPromise.reject(new window.AggregateError([]));
-    }
-    /* jshint ignore:end */
-
-    return SynchronousPromise.reject({ errors: [] });
+    return SynchronousPromise.reject(createAggregateErrorFrom([]));
   }
   return new SynchronousPromise(function (resolve, reject) {
     var
@@ -370,14 +374,7 @@ SynchronousPromise.any = function () {
       numRejected = 0,
       doReject = function () {
         if (numRejected === args.length) {
-          /* jshint ignore:start */
-          if (typeof window !== "undefined" && "AggregateError" in window) {
-            reject(new window.AggregateError(allErrors));
-            return;
-          }
-          /* jshint ignore:end */
-
-          reject({ errors: allErrors });
+          reject(createAggregateErrorFrom(allErrors));
         }
       },
       resolved = false,

--- a/index.spec.js
+++ b/index.spec.js
@@ -842,6 +842,43 @@ describe("synchronous-promise", function () {
       expect(capturedError).property("errors").to.contain("123");
     });
 
+    it("should reject with AggregateError if supported", function () {
+
+      /** Mock of AggregateError */
+      class AggregateError extends Error {
+        constructor(errors, message) {
+          super(message)
+          this.name = "AggregateError"
+          this.errors = errors
+        }
+      }
+
+      // Mock window object with AggregateError
+      const windowRef = global.window
+      global.window = { AggregateError }
+
+      // Test with only rejected promises
+      const p1 = createRejected("abc"),
+        any = SynchronousPromise.any(p1);
+      let capturedError = null;
+      any.catch(function (err) {
+        capturedError = err;
+      });
+
+      // Test with empty array
+      const anyEmpty = SynchronousPromise.any([]);
+      let capturedErrorEmpty = null;
+      anyEmpty.catch(function (err) {
+        capturedErrorEmpty = err;
+      })
+
+      expect(capturedError).to.be.instanceOf(AggregateError)
+      expect(capturedErrorEmpty).to.be.instanceOf(AggregateError)
+
+      // Restore window object
+      global.window = windowRef
+    });
+
     it("should reject with values in the correct order", function () {
       let reject1 = undefined,
         reject2 = undefined,

--- a/index.spec.js
+++ b/index.spec.js
@@ -847,15 +847,15 @@ describe("synchronous-promise", function () {
       /** Mock of AggregateError */
       class AggregateError extends Error {
         constructor(errors, message) {
-          super(message)
-          this.name = "AggregateError"
-          this.errors = errors
+          super(message);
+          this.name = "AggregateError";
+          this.errors = errors;
         }
       }
 
       // Mock window object with AggregateError
-      const windowRef = global.window
-      global.window = { AggregateError }
+      const windowRef = global.window;
+      global.window = { AggregateError };
 
       // Test with only rejected promises
       const p1 = createRejected("abc"),
@@ -872,11 +872,11 @@ describe("synchronous-promise", function () {
         capturedErrorEmpty = err;
       })
 
-      expect(capturedError).to.be.instanceOf(AggregateError)
-      expect(capturedErrorEmpty).to.be.instanceOf(AggregateError)
+      expect(capturedError).to.be.instanceOf(AggregateError);
+      expect(capturedErrorEmpty).to.be.instanceOf(AggregateError);
 
       // Restore window object
-      global.window = windowRef
+      global.window = windowRef;
     });
 
     it("should reject with values in the correct order", function () {

--- a/index.spec.js
+++ b/index.spec.js
@@ -842,43 +842,6 @@ describe("synchronous-promise", function () {
       expect(capturedError).property("errors").to.contain("123");
     });
 
-    it("should reject with AggregateError if supported", function () {
-
-      /** Mock of AggregateError */
-      class AggregateError extends Error {
-        constructor(errors, message) {
-          super(message);
-          this.name = "AggregateError";
-          this.errors = errors;
-        }
-      }
-
-      // Mock window object with AggregateError
-      const windowRef = global.window;
-      global.window = { AggregateError };
-
-      // Test with only rejected promises
-      const p1 = createRejected("abc"),
-        any = SynchronousPromise.any(p1);
-      let capturedError = null;
-      any.catch(function (err) {
-        capturedError = err;
-      });
-
-      // Test with empty array
-      const anyEmpty = SynchronousPromise.any([]);
-      let capturedErrorEmpty = null;
-      anyEmpty.catch(function (err) {
-        capturedErrorEmpty = err;
-      })
-
-      expect(capturedError).to.be.instanceOf(AggregateError);
-      expect(capturedErrorEmpty).to.be.instanceOf(AggregateError);
-
-      // Restore window object
-      global.window = windowRef;
-    });
-
     it("should reject with values in the correct order", function () {
       let reject1 = undefined,
         reject2 = undefined,
@@ -901,6 +864,54 @@ describe("synchronous-promise", function () {
 
       expect(capturedError).to.have.property("errors");
       expect(capturedError).property("errors").to.deep.equal(["b", "a"]);
+    });
+
+    describe("in browsers supporting AggregateError", function() {
+
+      // Used to restore previous global.window value
+      let windowRef = null;
+  
+      /** Mock of AggregateError */
+      class AggregateError extends Error {
+        constructor(errors, message) {
+          super(message);
+          this.name = "AggregateError";
+          this.errors = errors;
+        }
+      }
+  
+      beforeEach(function() {
+        // Mock window object with AggregateError
+        windowRef = global.window;
+        global.window = { AggregateError };
+      });
+  
+      afterEach(function () {
+        // Restore window object
+        global.window = windowRef;
+        windowRef = null;
+      });
+  
+      it("should reject with AggregateError for empty promise array", function () {
+        const anyEmpty = SynchronousPromise.any([]);
+        let capturedError = null;
+        anyEmpty.catch(function (err) {
+          capturedError = err;
+        });
+
+        expect(capturedError).to.be.instanceOf(AggregateError);
+      });
+
+      it("should reject with AggregateError for rejected promises as variable args", function () {
+        const p1 = createRejected("abc"),
+          any = SynchronousPromise.any(p1);
+        let capturedError = null;
+        any.catch(function (err) {
+          capturedError = err;
+        });
+  
+        expect(capturedError).to.be.instanceOf(AggregateError);
+      });
     });
   });
 


### PR DESCRIPTION
This adds the [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError/AggregateError) spec to the `SynchronousPromise.any` method. ([Promise.any](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/any#Description))

If `window` and `window.AggregateError` are defined, the method rejects with an instance of `AggregateError`.

I disabled JSHint for both of the blocks to allow the undefined `window` variable to be safely used after the checks.

The tests define a simple mock for the error and check if that implementation was used correctly.

This closes #24 
